### PR TITLE
Add source configuration option

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -55,3 +55,15 @@ options:
     default: 0
     description: Minimum transfer speed in mbit/s required to pass the test. 0 disables.
     type: int
+  source:
+    default: distro
+    type: string
+    description: |
+      Repository to add to unit before installing any dependencies.
+
+      May be one of the following:
+
+        distro (default)
+        ppa:somecustom/ppa (PPA name must include UCA OpenStack Release name)
+        deb url sources entry|key id
+        or a supported Ubuntu Cloud Archive pocket.

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,0 +1,2 @@
+# charmhelpers.contrib.openstack.utils pulls in a dep that require this
+netifaces


### PR DESCRIPTION
This will enable users of the charm to influence where any
dependencies to be installed on the unit come from.

It will also empower users who use magpie as a principle charm to
test subordinate charms as subordinate charms generally do not
have the power to configure package source.