### PR TITLE
Use network_get to retrieve the IP of the correct reference interface

### DIFF
--- a/src/lib/charms/layer/magpie_tools.py
+++ b/src/lib/charms/layer/magpie_tools.py
@@ -311,7 +311,7 @@ def check_bonds(bonds, lldp=None):
 
 def check_nodes(nodes, iperf_client=False):
     cfg = hookenv.config()
-    local_ip = hookenv.unit_private_ip()
+    local_ip = hookenv.network_get("magpie")['ingress-addresses'][0]
     iface_lines = subprocess.check_output(["ip", "route", "show", "to",
                                            "match", local_ip]).decode()
     iface_lines = iface_lines.split('\n')


### PR DESCRIPTION
As per bug https://github.com/openstack-charmers/magpie-layer/issues/17,
the use of the hook tool `unit-get private-address` is problematic since
it doesn't always get the correct IP when there are multiple interfaces
on the machine. This change ensures that we explicitly state that we
want to get the IP of the magpie binding.