### PR TITLE
Add automatic bond health checks

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,7 +1,7 @@
 options:
   check_bonds:
-    default: ''
-    description: Comma separated list of expected bonds
+    default: AUTO
+    description: Comma separated list of expected bonds or AUTO to check all available bonds.
     type: string
   use_lldp:
     default: false


### PR DESCRIPTION
This change attempts to simplify the process of checking bond health by
automatically detecting the bonds that are present in the machine.